### PR TITLE
Make debug queue a little more readable

### DIFF
--- a/lib/lita/handlers/debug_queue.rb
+++ b/lib/lita/handlers/debug_queue.rb
@@ -42,7 +42,7 @@ module Lita
 
       def show(response)
         return unless check_room!(response)
-        response.reply("Queue for #{@room.name} => #{@room.queue}")
+        response.reply("Queue for #{@room.name}:\n#{@room}")
       end
 
       def count(response)

--- a/lib/lita/handlers/room_queue.rb
+++ b/lib/lita/handlers/room_queue.rb
@@ -9,7 +9,7 @@ module Lita
       end
 
       def to_s
-        return self.queue.join('\n')
+        self.queue.join('\n')
       end
 
       def queue

--- a/lib/lita/handlers/room_queue.rb
+++ b/lib/lita/handlers/room_queue.rb
@@ -8,6 +8,10 @@ module Lita
         @redis = redis
       end
 
+      def to_s
+        return self.queue.join('\n')
+      end
+
       def queue
         data = @redis.get(@name)
         data ? MultiJson.load(data) : []


### PR DESCRIPTION
I think this will make the `debug queue` command easier to digest.

**WARNING**. I did not test this code.
